### PR TITLE
Use mDNS to set hostname.

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -10,6 +10,7 @@
     "WS2812B_PIN": 27,
     "ENABLE_MAX7219": false,
     "ENABLE_HT16K33": false,
-    "ENABLE_WS2812B": true
+    "ENABLE_WS2812B": true,
+    "HOSTNAME": "wordclock"
   }
   

--- a/src/gurgleapps_webserver.py
+++ b/src/gurgleapps_webserver.py
@@ -65,7 +65,7 @@ class GurgleAppsWebserver:
         }
         return status_names.get(status, str(status))
 
-    async def connect_wifi(self, ssid, password):
+    async def connect_wifi(self, ssid, password, hostname=None):
         if self.wifi_connecting:
             return False
 
@@ -85,6 +85,8 @@ class GurgleAppsWebserver:
                 print("Not connected to Wi-Fi.")
 
             # Activate Wi-Fi mode and connect
+            if hostname:
+                network.hostname(hostname)
             self.wlan_sta.active(True)
             await asyncio.sleep(1)
             self.wlan_sta.connect(ssid, password)

--- a/src/main.py
+++ b/src/main.py
@@ -1387,8 +1387,9 @@ async def connect_to_wifi():
     if wifi_ssid:
         # Password could be blank for open networks
         wifi_password = config.get('WIFI_PASSWORD', None)
+        hostname = config.get('HOSTNAME', 'wordclock')
         print("Connecting to Wi-Fi")
-        await server.connect_wifi(wifi_ssid, wifi_password)
+        await server.connect_wifi(wifi_ssid, wifi_password, hostname)
         if server.is_wifi_connected():
             print(f"Connected to Wi-Fi ip: {server.get_wifi_ip_address()}")
             await show_string(server.get_wifi_ip_address())


### PR DESCRIPTION
This is a small update to set a (configurable) hostname for the clock when it connects to wifi.

The advantage is that you can then just open a browser to http://wordclock.local to configure it - assuming that your network supports mDNS / Bonjour name resolution.